### PR TITLE
ci: add production-build smoke gate and init-order lint guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,15 @@ jobs:
       - name: E2E tests
         run: xvfb-run pnpm --filter desktop run test:e2e
 
+      # Production-build smoke (v0.3.0 white-screen guard): the E2E suite above
+      # runs ONLY against the Vite dev server, so production-only startup
+      # failures — module init order, minification, code-splitting, CSP — are
+      # structurally invisible to it (that class of bug shipped in v0.3.0). This
+      # serves the bundle produced by "Desktop web build" via `vite preview` and
+      # asserts the app boots and renders its first screen with no uncaught error.
+      - name: Production build smoke
+        run: xvfb-run pnpm --filter desktop run test:e2e:prod
+
   rust:
     name: Rust checks
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,18 @@ jobs:
           pnpm lint
           pnpm test
 
+      # Production-build smoke before we cut installers (v0.3.0 shipped a
+      # production-only white-screen). Run once on Linux: the web bundle under
+      # test is OS-independent and the check runs in Playwright's Chromium, not
+      # the platform webview, so a single leg covers all three installers.
+      - name: Install Playwright Browsers (smoke)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: pnpm --filter desktop exec playwright install --with-deps chromium
+
+      - name: Production build smoke
+        if: matrix.platform == 'ubuntu-22.04'
+        run: xvfb-run pnpm --filter desktop run smoke:prod
+
       - name: Build Tauri App
         # tauri-action v1 (migrated from v0). The inputs we use (tagName,
         # releaseName, releaseBody, releaseDraft, prerelease, args) are unchanged;

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,6 @@
-# Mirror the full CI (lint + typecheck + unit tests + E2E/axe).
+# Mirror the full CI (lint + typecheck + unit tests + E2E/axe + production-build
+# smoke). `test:all` ends with the desktop `smoke:prod`, which builds the bundle
+# and asserts it boots under `vite preview` (v0.3.0 production-only white-screen).
 # Note: this checks the WORKING TREE, not the pushed commit — with multi-file
 # features still run `git add -A` (after reviewing `git status`) so no file is
 # left behind (see CI lesson from 2026-06-30, missing blockTransforms.ts).

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ pnpm install --frozen-lockfile
 
 pnpm --filter desktop tauri dev     # run the desktop app
 pnpm test && pnpm lint && pnpm typecheck   # checks
-pnpm --filter desktop test:e2e      # Playwright E2E
+pnpm --filter desktop test:e2e      # Playwright E2E (Vite dev server)
+pnpm --filter desktop smoke:prod    # production-build smoke (vite build + preview + boot check)
 ```
 
 The repo is a pnpm/Turborepo monorepo: `apps/desktop` (Tauri v2 + React + CodeMirror 6), `packages/core` (vault logic: indexing, sync, merge — UI-free and heavily unit-tested), `docs/` (user guide, ADRs, engineering notes).

--- a/apps/desktop/e2e-prod/prod-smoke.spec.ts
+++ b/apps/desktop/e2e-prod/prod-smoke.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Production-build smoke check.
+ *
+ * The rest of the E2E suite (../e2e) runs against the Vite DEV server, so it
+ * cannot see failures that only exist in the bundled PRODUCTION build: module
+ * init order, minification, code-splitting or CSP. v0.3.0 shipped a white-screen
+ * exactly there — searchSnippet.tsx read a class static at module top level and
+ * the production bundle evaluated that module before the class initialized,
+ * throwing during startup (see commit c5d6a7e). Dev never hit it.
+ *
+ * This spec loads the real `vite build` output (served by `vite preview`, wired
+ * in playwright.prod.config.ts) and asserts the app actually boots. It runs with
+ * NO Tauri mock on purpose: that is precisely how the fix was verified by hand,
+ * and it keeps the check a pure "does the bundle come up" signal. Because the
+ * Tauri backend is absent, the settings store logs a handled
+ * "Cannot read properties of undefined (reading 'invoke')" to console.error and
+ * the app degrades to the splash — so we must NOT assert on console.error here.
+ * The startup crash we guard against instead surfaces as an UNCAUGHT pageerror
+ * plus an empty #root, which is what these assertions look for.
+ */
+test('production bundle boots and renders the splash without an uncaught error', async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', (err) => pageErrors.push(err.message));
+
+  await page.goto('/');
+
+  // The splash is the default entry screen. Its presence proves the bundle
+  // evaluated, React mounted and the first real screen rendered (not just an
+  // ErrorBoundary fallback). Startup is async — main.tsx renders inside
+  // i18nReady.then(...) after the locale chunk loads — so allow a generous wait.
+  await expect(
+    page.getByText(/Willkommen bei Plainva|Welcome to Plainva/),
+  ).toBeVisible({ timeout: 15000 });
+
+  // Belt and suspenders: a white-screen leaves #root empty even if some other
+  // element happened to match the text.
+  await expect(page.locator('#root > *').first()).toBeVisible();
+
+  // A module-init / bundle-evaluation crash throws OUTSIDE any handler, so it
+  // arrives as an uncaught pageerror. Report the messages on failure.
+  expect(pageErrors, `Uncaught page errors during startup:\n${pageErrors.join('\n')}`).toEqual([]);
+});

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,6 +12,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
+    "test:e2e:prod": "playwright test --config playwright.prod.config.ts",
+    "smoke:prod": "pnpm build && pnpm test:e2e:prod",
     "test:native": "wdio run ./wdio.conf.ts"
   },
   "dependencies": {

--- a/apps/desktop/playwright.prod.config.ts
+++ b/apps/desktop/playwright.prod.config.ts
@@ -1,0 +1,48 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright config for the PRODUCTION-build smoke check (../e2e-prod).
+ *
+ * Unlike the default config (playwright.config.ts), which runs the full suite
+ * against the Vite dev server, this one runs a single tiny spec against the
+ * bundled output served by `vite preview`. It exists to catch production-only
+ * startup failures (module init order, minification, code-splitting, CSP) that
+ * the dev-server suite is structurally blind to.
+ *
+ * `vite preview` serves an existing `dist/`, so a `vite build` must have run
+ * first: the `smoke:prod` script does that; in CI the dedicated build step does.
+ * Set E2E_BASE_URL to point at an already-running preview instead.
+ */
+const baseURL = process.env.E2E_BASE_URL || 'http://localhost:4173';
+
+export default defineConfig({
+  testDir: './e2e-prod',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: 'list',
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  ...(process.env.E2E_BASE_URL
+    ? {}
+    : {
+        webServer: {
+          // Serves apps/desktop/dist (must be built first). --strictPort makes a
+          // busy 4173 fail loudly instead of drifting to another port the tests
+          // would never reach.
+          command: 'pnpm preview --port 4173 --strictPort',
+          url: baseURL,
+          reuseExistingServer: !process.env.CI,
+          timeout: 120 * 1000,
+        },
+      }),
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,82 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 
+// Local flat-config plugin. Guards the exact footgun behind the v0.3.0
+// production white-screen: searchSnippet.tsx read `VaultQueryService.SNIPPET_MARK_START`
+// at module top level, and in the bundled build this module evaluated before
+// VaultQueryService initialized (module ordering differs from the Vite dev
+// server), throwing at startup. The rule flags eager (module-init-time) reads of
+// SCREAMING_SNAKE statics off an imported binding — read them lazily instead.
+const plainvaPlugin = {
+  rules: {
+    "no-top-level-imported-static-read": {
+      meta: {
+        type: "problem",
+        docs: {
+          description:
+            "Disallow reading a CONSTANT-style static member off an imported binding at module-init time (production bundle ordering can leave the import uninitialized).",
+        },
+        schema: [],
+        messages: {
+          eager:
+            "Do not read '{{object}}.{{property}}' from an imported binding at module top level: in the production bundle this module can evaluate before '{{object}}' is initialized (module ordering differs from the Vite dev server), throwing at startup. Read it lazily inside a function/getter instead (v0.3.0 white-screen: searchSnippet.tsx).",
+        },
+      },
+      create(context) {
+        const importedNames = new Set();
+
+        // A member read is "eager" when it runs while the module initializes —
+        // module top level, a top-level declaration's initializer, or a static
+        // class-field initializer. Crossing any function boundary on the way up
+        // to Program means the read is deferred to call time, which is safe.
+        function isEager(node) {
+          let cur = node.parent;
+          while (cur && cur.type !== "Program") {
+            if (
+              cur.type === "FunctionDeclaration" ||
+              cur.type === "FunctionExpression" ||
+              cur.type === "ArrowFunctionExpression"
+            ) {
+              return false;
+            }
+            cur = cur.parent;
+          }
+          return true;
+        }
+
+        function recordImport(node) {
+          // Type-only imports are erased at build time and cannot be read as
+          // values, so they are never the footgun.
+          if (node.importKind === "type") return;
+          if (node.parent && node.parent.importKind === "type") return;
+          importedNames.add(node.local.name);
+        }
+
+        return {
+          ImportDefaultSpecifier: recordImport,
+          ImportNamespaceSpecifier: recordImport,
+          ImportSpecifier: recordImport,
+          MemberExpression(node) {
+            if (node.computed) return;
+            if (node.object.type !== "Identifier") return;
+            if (node.property.type !== "Identifier") return;
+            // Only CONSTANT_CASE members — the class-static-constant shape. Keeps
+            // the rule off ordinary camelCase property reads of imported objects.
+            if (!/^[A-Z][A-Z0-9_]*$/.test(node.property.name)) return;
+            if (!importedNames.has(node.object.name)) return;
+            if (!isEager(node)) return;
+            context.report({
+              node,
+              messageId: "eager",
+              data: { object: node.object.name, property: node.property.name },
+            });
+          },
+        };
+      },
+    },
+  },
+};
+
 export default tseslint.config(
   {
     ignores: [
@@ -100,6 +176,18 @@ export default tseslint.config(
       ],
       "no-console": "off",
       "react-refresh/only-export-components": "off",
+    },
+  },
+  {
+    // Production-bundle init-order guard across all shipped source (desktop, ui,
+    // core, mobile). Scoped to `src`, minus co-located tests: test files run
+    // under Vitest (eager, correct module order like the dev server) and are
+    // never in the shipped bundle, so the footgun cannot apply to them.
+    files: ["**/src/**/*.{ts,tsx}"],
+    ignores: ["**/*.test.{ts,tsx}", "**/*.spec.{ts,tsx}"],
+    plugins: { plainva: plainvaPlugin },
+    rules: {
+      "plainva/no-top-level-imported-static-read": "error",
     },
   },
 );

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "test": "turbo run test",
-    "test:all": "turbo run test && pnpm --filter desktop test:e2e",
+    "test:all": "turbo run test && pnpm --filter desktop test:e2e && pnpm --filter desktop smoke:prod",
     "typecheck": "turbo run typecheck",
     "prepare": "husky"
   },


### PR DESCRIPTION
## What & why

The E2E suite runs only against the Vite dev server, so production-only startup
failures (module init order, minification, code-splitting, CSP) are structurally
invisible to it. v0.3.0 shipped a white-screen exactly there: `searchSnippet.tsx`
read a class static at module top level and the production bundle evaluated that
module before the class initialized, throwing at startup (fixed in c5d6a7e). This
adds the missing gate.

## Changes

- **Production-build smoke** — `apps/desktop/e2e-prod/prod-smoke.spec.ts` +
  `playwright.prod.config.ts`: serve the `vite build` output via `vite preview`
  and assert the app boots and renders its first screen with no uncaught error.
  It runs with no Tauri backend on purpose (exactly how the fix was verified by
  hand): the store then logs a handled console error and the app degrades to the
  splash, so the check asserts on the uncaught pageerror + empty `#root` a real
  crash produces — not on console output.
- **Scripts** — desktop `test:e2e:prod` (reuses a built `dist`, for CI) and
  `smoke:prod` (self-contained build + preview + check).
- **Wiring** — CI (`ci.yml`), the release pre-flight (`release.yml`, Linux only:
  the web bundle is OS-independent and the check runs in Playwright's Chromium,
  not the platform webview), and the pre-push mirror via `test:all`.
- **Lint guard** — `plainva/no-top-level-imported-static-read` flags eager,
  module-init-time reads of CONSTANT-case statics off imported bindings (the
  exact footgun), so this class of bug fails lint before it can ship. Co-located
  tests are exempt (Vitest init order is correct and they are never bundled).

## Verification

- `smoke:prod` passes on the fixed build; reverting c5d6a7e makes it fail (splash
  never renders; uncaught pageerror `Cannot read properties of undefined (reading
  'SNIPPET_MARK_START')`).
- The lint guard flags the original buggy `searchSnippet.tsx` (2 errors on the
  top-level reads) and is clean on current source.
- `pnpm lint`, `pnpm typecheck`, and the full pre-push mirror (unit tests +
  dev E2E + prod smoke) all pass.
