### PR TITLE
Deflake the recursive fs.watch test on macOS CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ on:
   push:
     tags:
       - 'v*'
+  # Manual trigger to dry-run the pre-flight (lint + full test suite) on all
+  # three platforms without cutting a release. The macOS leg of `pnpm test`
+  # exercises the recursive fs.watch path (FSEvents), which the ubuntu-only CI
+  # workflow never runs — this is the on-demand way to confirm that path stays
+  # green. The release-cutting steps below are gated off for manual runs.
+  workflow_dispatch:
 
 jobs:
   release:
@@ -59,14 +65,18 @@ jobs:
       # test is OS-independent and the check runs in Playwright's Chromium, not
       # the platform webview, so a single leg covers all three installers.
       - name: Install Playwright Browsers (smoke)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-22.04' && github.event_name != 'workflow_dispatch'
         run: pnpm --filter desktop exec playwright install --with-deps chromium
 
       - name: Production build smoke
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-22.04' && github.event_name != 'workflow_dispatch'
         run: xvfb-run pnpm --filter desktop run smoke:prod
 
       - name: Build Tauri App
+        # Release-cutting step: only on a tag push. A manual workflow_dispatch
+        # stops after the pre-flight above, so it never builds installers or
+        # creates a draft release named after the branch ref.
+        if: github.event_name != 'workflow_dispatch'
         # tauri-action v1 (migrated from v0). The inputs we use (tagName,
         # releaseName, releaseBody, releaseDraft, prerelease, args) are unchanged;
         # v1 only drops includeRelease/includeDebug/auto-init and renames

--- a/packages/core/test/local-vault-adapter.test.ts
+++ b/packages/core/test/local-vault-adapter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { LocalVaultAdapter } from "../src/vault/LocalVaultAdapter.ts";
-import { VaultFileNotFoundError, VaultFileExistsError, VaultPermissionDeniedError } from "../src/vault/IVaultAdapter.ts";
+import { VaultFileNotFoundError, VaultFileExistsError, VaultPermissionDeniedError, WatchEvent } from "../src/vault/IVaultAdapter.ts";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
@@ -109,26 +109,53 @@ describe("LocalVaultAdapter", () => {
     await expect(adapter.writeTextFile("../outside.txt", "data")).rejects.toThrow(VaultPermissionDeniedError);
   });
 
-  it("can watch for file changes", async () => {
+  // Node's recursive fs.watch is backed by macOS FSEvents, whose stream arms
+  // asynchronously *after* watch() resolves and whose delivery coalesces under
+  // load. A single write fired right after arming can therefore land before the
+  // stream is live and be lost forever, and even a delivered event can lag past
+  // a tight cap on a busy CI runner — which is why the old single-write / 2s
+  // version flaked the macOS release job. The fix is pure test harness: keep
+  // re-writing until the event is observed (defeating the arming race) under a
+  // generous ceiling. `retry` is a last-resort net so a pathological one-off
+  // stall can never fail a release; the per-test timeout sits above
+  // WATCH_TIMEOUT_MS so our descriptive error wins over Vitest's default.
+  it("can watch for file changes", { retry: 2, timeout: 15000 }, async () => {
+    const WATCH_TIMEOUT_MS = 10000;
+    const WRITE_INTERVAL_MS = 100;
+
     let unwatch: (() => void) | undefined;
+    let pollTimer: ReturnType<typeof setInterval> | undefined;
+    let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+
     try {
       const eventReceived = new Promise<void>((resolve) => {
-        const checkEvent = (events: any[]) => {
-          if (events.some(e => e.path.includes("watch-test.txt"))) {
+        const checkEvent = (events: WatchEvent[]) => {
+          if (events.some((e) => e.path.includes("watch-test.txt"))) {
             resolve();
           }
         };
-        adapter.watch(checkEvent).then(u => {
+        adapter.watch(checkEvent).then((u) => {
           unwatch = u;
-          // Trigger a change
-          adapter.writeTextFile("watch-test.txt", "changed");
+          // Re-issue the write until the watcher reports it, so the test never
+          // depends on winning the FSEvents startup race. Swallow write errors:
+          // during teardown the temp dir may already be gone.
+          let n = 0;
+          const trigger = () => {
+            void adapter.writeTextFile("watch-test.txt", `changed ${n++}`).catch(() => {});
+          };
+          trigger();
+          pollTimer = setInterval(trigger, WRITE_INTERVAL_MS);
         });
       });
 
-      // Wait up to 2 seconds for the event
-      const timeout = new Promise((_, reject) => setTimeout(() => reject(new Error("Watch event timeout")), 2000));
+      const timeout = new Promise<never>((_, reject) => {
+        timeoutTimer = setTimeout(() => reject(new Error("Watch event timeout")), WATCH_TIMEOUT_MS);
+      });
+
       await Promise.race([eventReceived, timeout]);
     } finally {
+      if (pollTimer) clearInterval(pollTimer);
+      if (timeoutTimer) clearTimeout(timeoutTimer);
       if (unwatch) unwatch();
     }
   });


### PR DESCRIPTION
## Problem

`can watch for file changes` in `packages/core/test/local-vault-adapter.test.ts` sporadically fails on the `macos-latest` release runner with `Watch event timeout`. The release workflow runs a `Build and Test Pre-flight` (`pnpm test`) before the Tauri build, so this timing flake fails the macOS job and blocks the whole desktop release until someone runs `gh run rerun <id> --failed`. It hit exactly this at v0.3.1 — Linux + Windows green, only macOS timed out.

## Root cause

Node's recursive `fs.watch` is backed by macOS **FSEvents**, whose stream **arms asynchronously after `watch()` resolves** and coalesces delivery under load. The old test issued a **single** write immediately after arming and waited at most **2s**:

- under CI load the write can land **before** the stream is live and be **lost forever**, and
- even a delivered event can lag past 2s on a busy runner.

Both are pure test-harness timing assumptions. `LocalVaultAdapter.watch` forwards events immediately (no debounce), so no product code is involved.

## Fix (test-only)

- **Poll-until-observed** — re-issue the write every 100 ms until the watcher reports it, defeating the arming race.
- **Generous ceiling** — 10 s internal timeout (was 2 s), with the Vitest per-test `timeout: 15000` above it so the descriptive `Watch event timeout` error still wins over Vitest's default.
- **`retry: 2`** as a last-resort net so a pathological one-off runner stall can never fail a release.
- Timers and the watcher are cleaned up in `finally`.

## Enabling on-demand macOS verification

`ci.yml` is ubuntu-only; the macOS test path exists only in `release.yml`, which fired on tag push. This PR adds a **guarded `workflow_dispatch`** to `release.yml`: a manual run executes only the lint + test pre-flight on macOS/Linux/Windows. The production-build smoke and the `tauri-action` build/draft are gated to tag pushes via `github.event_name`, so a manual dispatch **never cuts a release**.

After this lands on `main` (GitHub exposes `workflow_dispatch` from the default branch):

```
gh workflow run release.yml
```

Then confirm the macOS leg's `Build and Test Pre-flight` is green. No draft release is created.

## Verification

- Core suite 606/606; lint + typecheck clean.
- Watch test 25/25 under local stress — stable, no timer/watcher leaks.
- OS-independent simulation: with an 800 ms arming delay the old single-write / 2 s harness times out (reproduces the flake), while the new poll / 10 s harness catches the first post-arming write (~870 ms).
- Full local pre-push (lint + typecheck + unit + E2E + production-build smoke) green.
