### PR TITLE
test(desktop): stabilize listDepthAt tests against async parse race

### DIFF
--- a/apps/desktop/src/components/listIndent.test.ts
+++ b/apps/desktop/src/components/listIndent.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { EditorState } from "@codemirror/state";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
+import { ensureSyntaxTree } from "@codemirror/language";
 import { isListMarkerLine, listIndentStyle, listDepthAt } from "@plainva/ui";
 
 describe("isListMarkerLine", () => {
@@ -39,7 +40,15 @@ describe("listIndentStyle", () => {
 });
 
 describe("listDepthAt", () => {
-  const stateFor = (doc: string) => EditorState.create({ doc, extensions: [markdown({ base: markdownLanguage })] });
+  const stateFor = (doc: string) => {
+    const state = EditorState.create({ doc, extensions: [markdown({ base: markdownLanguage })] });
+    // Lezer parses markdown asynchronously; under full-suite parallel load the
+    // background parse can trail the deeper list lines, so listDepthAt would read
+    // an incomplete tree and report 0. Force a complete parse up front to keep the
+    // depth assertions deterministic (mirrors editorSession.test.ts).
+    ensureSyntaxTree(state, state.doc.length, 5000);
+    return state;
+  };
   // First non-whitespace position of a 1-based line number.
   const firstNonWs = (state: EditorState, lineNo: number) => {
     const line = state.doc.line(lineNo);


### PR DESCRIPTION
Makes the `listDepthAt` unit tests deterministic under full-suite parallel load.

The tests built a bare `EditorState` and immediately called `listDepthAt`, which reads `syntaxTree(state)`. Under parallel load the asynchronous lezer parse could trail the deeper list lines, so the tree was incomplete and depth read as 0 (`expected +0 to be 1`). It passed in isolation, which is what flagged it as a race rather than a regression.

Fix: force a complete parse via `ensureSyntaxTree(state, state.doc.length, 5000)` in the shared `stateFor` helper before the depth assertions — mirroring the pattern already used in `editorSession.test.ts`. Test-only; `packages/ui/src/components/listIndent.ts` is unchanged.

Verified: targeted test 8/8 in isolation; full `pnpm test` green across three forced parallel runs (167 files / 1884 tests each); `pnpm lint` and `pnpm typecheck` clean.
