### PR TITLE
Normalize Unicode in Base folder queries

### DIFF
--- a/packages/core/src/vault/VaultQueryService.ts
+++ b/packages/core/src/vault/VaultQueryService.ts
@@ -932,16 +932,24 @@ export class VaultQueryService {
     `;
     const params: any[] = [];
 
+    // APFS commonly reports decomposed (NFD) paths while Base files usually
+    // contain composed (NFC) folder names. SQLite compares both byte-for-byte,
+    // so query both canonical Unicode forms to keep folder sources portable.
+    const folderPathClause = (folder: string, contains = false): string => {
+      if (!folder.endsWith("/")) folder += "/";
+      const variants = [...new Set([folder.normalize("NFC"), folder.normalize("NFD")])];
+      for (const variant of variants) params.push(contains ? `%${variant}%` : `${variant}%`);
+      return variants.length === 1 ? `f.path LIKE ?` : `(${variants.map(() => "f.path LIKE ?").join(" OR ")})`;
+    };
+
     // 1. Process filters
     const parseFilter = (filter: any): string | null => {
       if (typeof filter === "string") {
         const folderMatch = filter.match(/file\.folder\s*==\s*"([^"]+)"/);
         if (folderMatch) {
-          let folder = folderMatch[1];
+          const folder = folderMatch[1];
           if (folder === "/") return "1=1";
-          if (!folder.endsWith("/")) folder += "/";
-          params.push(`${folder}%`);
-          return `f.path LIKE ?`;
+          return folderPathClause(folder);
         }
         
         const tagMatch = filter.match(/file\.hasTag\("([^"]+)"\)/);
@@ -953,11 +961,9 @@ export class VaultQueryService {
         }
       } else if (typeof filter === "object" && filter !== null) {
         if (filter.field === 'file.folder' && filter.value) {
-          let folder = String(filter.value);
+          const folder = String(filter.value);
           if (folder === "/") return "1=1";
-          if (!folder.endsWith("/")) folder += "/";
-          params.push(`%${folder}%`);
-          return `f.path LIKE ?`;
+          return folderPathClause(folder, true);
         }
       }
       

--- a/packages/core/test/vault-query.test.ts
+++ b/packages/core/test/vault-query.test.ts
@@ -253,6 +253,21 @@ describe("VaultQueryService", () => {
     expect(result.map((r) => r["file.path"])).toEqual(["Projects/Alpha.md"]);
   });
 
+  it("queries NFC and NFD variants of Base folder sources", async () => {
+    db.mockedResults.push([]);
+    const folder = "母/クレジットカード管理".normalize("NFC");
+    await queryService.queryDatabaseFiles({
+      filters: { and: [`file.folder == "${folder}"`] },
+      views: [{}],
+    });
+
+    expect(db.queries[0].query).toContain("(f.path LIKE ? OR f.path LIKE ?)");
+    expect(db.queries[0].params).toEqual([
+      `${folder.normalize("NFC")}/%`,
+      `${folder.normalize("NFD")}/%`,
+    ]);
+  });
+
   it("filters on a property whose name contains spaces", async () => {
     db.mockedResults.push([
       { id: "1", path: "a.md", title: "A", mtime_local: 100, size_bytes: 1 },


### PR DESCRIPTION
## What changed

- Query both NFC and NFD variants for Base folder source paths.
- Apply the same handling to legacy object-form folder filters.
- Add a regression test using a Japanese folder name with combining characters.

## Why

On macOS/APFS, vault paths can be indexed in decomposed Unicode (NFD), while an Obsidian-compatible `.base` file commonly stores the visually identical folder name in composed Unicode (NFC). SQLite `LIKE` compares these representations byte-for-byte, so the Base rendered correctly but returned zero entries.

This keeps Base folder sources portable without rewriting the `.base` file or the indexed path.

## Validation

- Core test suite: 105 files, 1,235 tests passed.
- Full unit suites: Core, Desktop, and Mobile passed.
- Typecheck passed.
- Lint passed with three pre-existing warnings.
- Desktop Playwright E2E: 244/254 passed; 10 unrelated UI timing tests failed. None cover the changed Core query code.

## Reproduction

1. Store a vault in iCloud Drive on macOS with a Japanese folder such as `母/クレジットカード管理` (APFS reports the path in NFD).
2. Reference that folder from a `.base` file using the visually identical NFC string.
3. Before this change, the Base shows zero entries; after this change, its notes are returned.