### PR TITLE
fix(desktop): allow dot-file inside dot-folder in fs scope

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -27,6 +27,9 @@
     }
   },
   "plugins": {
+    "fs": {
+      "requireLiteralLeadingDot": false
+    },
     "sql": {
       "preload": ["sqlite:plainva.db"]
     },

--- a/apps/desktop/src/fsScopeConfig.test.ts
+++ b/apps/desktop/src/fsScopeConfig.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * tauri-plugin-fs checks every path against the capability scope with the `glob`
+ * crate's `require_literal_leading_dot`, which defaults to `true` on Unix (Linux
+ * and macOS) and `false` on Windows. With the default on, `*`/`**` never match a
+ * path segment starting with `.`, so a dot-file inside a dot-folder (e.g. an
+ * Obsidian vault's `.attachments/.gitkeep` or `.rumdl_cache/.gitignore`) is
+ * rejected: no combination of glob patterns in capabilities/default.json covers
+ * two dot-segments in a row (issue #70). Turning the flag off here matches the
+ * Windows default everywhere and makes the existing `**` pattern sufficient.
+ */
+describe("fs plugin scope config", () => {
+  it("disables the Unix leading-dot glob restriction", () => {
+    const conf = JSON.parse(readFileSync(resolve(__dirname, "../src-tauri/tauri.conf.json"), "utf8"));
+    expect(conf?.plugins?.fs?.requireLiteralLeadingDot).toBe(false);
+  });
+});


### PR DESCRIPTION
## What & why

Opening an existing Obsidian vault that contains a dot-file inside a dot-folder — e.g. `.attachments/.gitkeep` or `.rumdl_cache/.gitignore` — fails with:

```
E rror: forbidden path: /path/to/vault/.attachments/.gitkeep, maybe it is not
  allowed on the scope for `allow-exists` permission in your capability file
```

`tauri-plugin-fs` checks every path against the capability scope using the `glob` crate's `require_literal_leading_dot` option, which defaults to `true` on Unix (Linux and macOS; Windows defaults to `false`). With it on, `*`/`**` never match a path segment starting with `.`. `apps/desktop/src-tauri/capabilities/default.json` already works around this with extra glob patterns (`**/.*`, `**/.*/**`, …) so a single dot-segment is allowed, but no combination of patterns covers **two dot-segments in a row** — a dot-file inside a dot-folder falls through every pattern and gets rejected.

## Fix

Set `requireLiteralLeadingDot: false` on the `fs` plugin in `tauri.conf.json`. This matches the Windows default everywhere and makes the existing plain `**` capability pattern sufficient on its own, regardless of how many dot-segments a path contains.

## Testing

- Added `apps/desktop/src/fsScopeConfig.test.ts`, asserting the config flag is set.
- `pnpm lint && pnpm typecheck && pnpm test:all` green.

Fixes #70

## Checklist

- [x] Tests cover the change and `pnpm test` is green.
- [x] `pnpm lint` and `pnpm typecheck` pass.
- [ ] New UI strings in all locales — n/a, no UI strings.
- [ ] Handbook pages updated — n/a, invisible bug fix, no new user-facing behavior to document.
- [x] Vault files stay Obsidian-openable — no vault-write path touched.
- [x] No secrets/private paths/vault contents in this PR.

---

This PR was AI-assisted (Claude Code).
