### PR TITLE
fix(desktop): resolve symlinked directories before classifying vault entries

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -27,6 +27,9 @@
     }
   },
   "plugins": {
+    "fs": {
+      "requireLiteralLeadingDot": false
+    },
     "sql": {
       "preload": ["sqlite:plainva.db"]
     },

--- a/apps/desktop/src/adapters/TauriVaultAdapter.ts
+++ b/apps/desktop/src/adapters/TauriVaultAdapter.ts
@@ -315,46 +315,54 @@ export class TauriVaultAdapter implements IVaultAdapter {
     // Stat every file (not just .md): attachments need a real mtime/size too, or
     // the indexer's mtime-based change detection treats them as changed every
     // pass and re-reads + re-hashes them. A stat() is far cheaper than that.
-    const results: VaultFileInfo[] = await Promise.all(
+    //
+    // readDir's `isDirectory` doesn't follow symlinks; stat()'s does, and must
+    // win — otherwise a symlinked directory (e.g. a venv's `lib64 -> lib`) is
+    // walked as a "file" and readTextFile crashes on it with EISDIR.
+    type ResolvedEntry = VaultFileInfo & { absPath: string };
+    const resolved: ResolvedEntry[] = await Promise.all(
       validEntries.map((entry) => {
         const relativeChildPath = path ? `${path}/${entry.name}` : entry.name!;
+        const childAbsPath = basePath + entry.name;
         if (entry.isDirectory) {
-          return Promise.resolve<VaultFileInfo>({
-            name: entry.name!, path: relativeChildPath, isDirectory: true,
+          return Promise.resolve<ResolvedEntry>({
+            name: entry.name!, path: relativeChildPath, absPath: childAbsPath, isDirectory: true,
             mtime: Date.now(), ctime: undefined, size: 0,
           });
         }
-        const childAbsPath = basePath + entry.name;
         return limit.run(async () => {
           let mtime = Date.now();
           let ctime: number | undefined;
           let size = 0;
+          let isDirectory = false;
           try {
             const entryStat = await stat(childAbsPath);
+            isDirectory = entryStat.isDirectory;
             mtime = entryStat.mtime?.getTime() || Date.now();
-            ctime = entryStat.birthtime?.getTime() || undefined;
-            size = entryStat.size;
+            ctime = isDirectory ? undefined : entryStat.birthtime?.getTime() || undefined;
+            size = isDirectory ? 0 : entryStat.size;
           } catch {
             console.warn(`Failed to stat ${childAbsPath}`);
           }
-          return { name: entry.name!, path: relativeChildPath, isDirectory: false, mtime, ctime, size };
+          return { name: entry.name!, path: relativeChildPath, absPath: childAbsPath, isDirectory, mtime, ctime, size };
         });
       })
     );
+
+    const results: VaultFileInfo[] = resolved.map(({ absPath: _absPath, ...info }) => info);
 
     // Recurse into subdirectories concurrently too; the shared limiter keeps the
     // total in-flight FS calls across the whole tree at LIST_CONCURRENCY. No call
     // holds a slot while awaiting children, so there is no deadlock. `visited`
     // guards symlink loops (the check+add is synchronous, before the first await).
+    // Filtered on the resolved isDirectory so a symlinked directory is descended into.
     if (recursive) {
       const childLists = await Promise.all(
-        validEntries
+        resolved
           .filter((e) => e.isDirectory)
-          .map((entry) => {
-            const relativeChildPath = path ? `${path}/${entry.name}` : entry.name!;
-            const childAbsPath = basePath + entry.name;
-            return this._listDirInternal(relativeChildPath, childAbsPath, true, visited, limit, skipped, depth + 1, insideInternal);
-          })
+          .map((entry) =>
+            this._listDirInternal(entry.path, entry.absPath, true, visited, limit, skipped, depth + 1, insideInternal)
+          )
       );
       for (const cl of childLists) results.push(...cl);
     }

--- a/apps/desktop/src/fsScopeConfig.test.ts
+++ b/apps/desktop/src/fsScopeConfig.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * tauri-plugin-fs checks every path against the capability scope with the `glob`
+ * crate's `require_literal_leading_dot`, which defaults to `true` on Unix (Linux
+ * and macOS) and `false` on Windows. With the default on, `*`/`**` never match a
+ * path segment starting with `.`, so a dot-file inside a dot-folder (e.g. an
+ * Obsidian vault's `.attachments/.gitkeep` or `.rumdl_cache/.gitignore`) is
+ * rejected: no combination of glob patterns in capabilities/default.json covers
+ * two dot-segments in a row (issue #70). Turning the flag off here matches the
+ * Windows default everywhere and makes the existing `**` pattern sufficient.
+ */
+describe("fs plugin scope config", () => {
+  it("disables the Unix leading-dot glob restriction", () => {
+    const conf = JSON.parse(readFileSync(resolve(__dirname, "../src-tauri/tauri.conf.json"), "utf8"));
+    expect(conf?.plugins?.fs?.requireLiteralLeadingDot).toBe(false);
+  });
+});


### PR DESCRIPTION
## What & why

Depends on #71. This branch stacks on it locally, but GitHub can't set a cross-repo PR's base to a branch that only exists on my fork, so **this diff currently shows both commits** — the #71 commit will drop out of this PR automatically once #71 merges into `main`.

While testing #71 against a real vault, opening one that had a Python virtualenv inside it (`tools/.venv`) crashed with:

```
Error: failed to read file as text at path: /path/to/vault/tools/.venv/lib64
with error: Is a directory (os error 21)
```

`.venv/lib64` is a symlink to a directory (standard venv layout). In `TauriVaultAdapter._listDirInternal`, the walker classified entries using `readDir`'s dirent `isDirectory`, which does **not** follow symlinks — so a symlink-to-directory reports `false` and is walked as a "file". The code separately called `stat()` on it (to get mtime/size), and `stat()` **does** follow symlinks and would have reported `isDirectory: true` correctly — but that result was discarded, with `isDirectory` hardcoded to `false` on the returned entry regardless. The entry was never recursed into, and the indexer later called `readTextFile` on what turned out to be a directory.

## Fix

Use `stat()`'s (symlink-following) `isDirectory` to decide both the entry's returned classification and whether the walk recurses into it, instead of trusting the raw dirent flag for non-directory entries. A symlinked directory is now treated as a directory end to end.

## Testing

- `pnpm lint && pnpm typecheck && pnpm test:all` green (`apps/desktop/src/adapters/TauriVaultAdapter.ts` has no existing unit tests or `@tauri-apps/plugin-fs` mocking convention to extend, so no new unit test was added for this one — flagging in case that's wanted before merge).

## Checklist

- [ ] Tests cover the change — see note above; no existing pattern to extend for this adapter.
- [x] `pnpm lint` and `pnpm typecheck` pass.
- [ ] New UI strings in all locales — n/a, no UI strings.
- [ ] Handbook pages updated — n/a, invisible bug fix, no new user-facing behavior to document.
- [x] Vault files stay Obsidian-openable — no vault-write path touched.
- [x] No secrets/private paths/vault contents in this PR.

---

This PR was AI-assisted (Claude Code).
